### PR TITLE
Add my signature. Defund and abolish ICE 🌹

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Signed,
 - Peter Squicciarini, @stripedpajamas (VSCodium)
 - Thorr Stevens, @thorrstevens (Javascript Developer, date-fns contributor)
 - Christoph Stock, @stockulus (Software Engineer)
+- Christopher Styles, @christopherstyles (Software Writer, allthefarms.com co-founder)
 - Colby Swandale, @colby-swandale (Bundler, Rubygems, RubyGems.org)
 - Gueorgui Tcherednitchenko, @gueorgui (A Possible Space)
 - Tilde Thurium, @annthurium (Atom Editor contributor, Write Speak Code organizer)


### PR DESCRIPTION
I am adding my signature, urging Github leadership to discontinue support of the Enforcement and Removal Operations (ERO) division of United States Immigrations and Customs Enforcement (ICE).

ICE is guilty of crimes against humanity, psychological and sexual abuse against children and the vulnerable. They should have no place in our society, and should be disincentivized to continue their abuses through a popular disavowment and boycott of their services. It speaks volumes about a company and its leadership, when it would knowingly continue to provide services to an entity that has abducted and imprisoned children, committed violent and racist acts, and committed sundry human rights violations.

Please repudiate ICE. Be ethical. Cancel their contract.
