### PR TITLE
Improve alphabetical checking

### DIFF
--- a/.github/workflows/validate.js
+++ b/.github/workflows/validate.js
@@ -105,9 +105,9 @@ console.log('✅ Signature is formatted correctly');
 
 
 //(naively) check alphabetization
-const beforeLastName = beforeLine[1].trim().split(',', 1)[0].split(/\s+/g).pop();
-const afterLastName = afterLine[1].trim().split(',', 1)[0].split(/\s+/g).pop();
-const lastName = line[1].trim().split(',', 1)[0].split(/\s+/g).pop();
+const beforeLastName = beforeLine[1].trim().split(',', 1)[0].split(/\s+/g).pop().toLowerCase();
+const afterLastName = afterLine[1].trim().split(',', 1)[0].split(/\s+/g).pop().toLowerCase();
+const lastName = line[1].trim().split(',', 1)[0].split(/\s+/g).pop().toLowerCase();
 
 if (beforeLastName > lastName || afterLastName < lastName) {
 	console.error('❗Signature does not appear to be alphabetical order');


### PR DESCRIPTION
Saw a few cases where lexicographic comparison was creating false negatives for the alphabetical check. Still doesn't cover all cases (e.g. https://github.com/drop-ice/dear-github-2.0/pull/694/files) but it should fix a few cases where someone's last name is lowercase.